### PR TITLE
fstab: add F2FS for system

### DIFF
--- a/rootdir/etc/fstab.qcom
+++ b/rootdir/etc/fstab.qcom
@@ -6,6 +6,7 @@
 /dev/block/platform/msm_sdcc.1/by-name/boot        /boot            emmc    defaults                                                                  recoveryonly
 /dev/block/platform/msm_sdcc.1/by-name/recovery    /recovery        emmc    defaults                                                                  recoveryonly
 /dev/block/platform/msm_sdcc.1/by-name/system      /system          ext4    ro,barrier=1,errors=panic                                                 wait
+/dev/block/platform/msm_sdcc.1/by-name/system      /system          f2fs    ro,nosuid,nodev,noatime,nodiratime,background_gc=on,user_xattr,acl        wait
 /dev/block/platform/msm_sdcc.1/by-name/apnhlos     /firmware        vfat    ro,shortname=lower,uid=1000,gid=1000,dmask=227,fmask=337,context=u:object_r:firmware_file:s0  wait
 /dev/block/platform/msm_sdcc.1/by-name/mdm         /firmware-mdm    vfat    ro,shortname=lower,uid=1000,gid=1000,dmask=227,fmask=337,context=u:object_r:firmware_file:s0  wait
 /dev/block/platform/msm_sdcc.1/by-name/efs         /efs             ext4    nosuid,nodev,noatime,noauto_da_alloc,journal_async_commit,errors=panic    wait,check


### PR DESCRIPTION
fs_mgr is smart enough. Tries to mount with the default fs type (in this case ext4), if fs is F2FS fails and mounts as it. /cache and /data are already F2FS-compatible here, why don't add /system too?
